### PR TITLE
Add KubeStellar Console to Tools and Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Command-line tools, dashboards, configuration utilities:
 - *[Zoo Entrance](https://github.com/scholzj/zoo-entrance)* - Proxy for opening direct connections to Apache ZooKeeper inside a Strimzi-based Apache Kafka cluster
 - *[ca-controller-for-strimzi](https://github.com/sebastiangaiser/ca-controller-for-strimzi)* - Creates Strimzi conform Kubernetes secrets from Kubernetes TLS secrets (e.g. created via cert-manager)
 - *[Streamshub-console](https://github.com/streamshub/console)* - Web application designed to facilitate interactions with Apache Kafka leveraging Strimzi operator custom resources.
+- *[KubeStellar Console](https://github.com/kubestellar/console)* - Multi-cluster Kubernetes dashboard with a guided [Strimzi install mission](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-strimzi.json)
 
 ### Integrations
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Tools and Utilities section.

KubeStellar Console is a multi-cluster Kubernetes dashboard with a guided [Strimzi install mission](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-strimzi.json) — step-by-step Helm/OCI install, verification, and troubleshooting.

Per request from @scholzj in https://github.com/strimzi/strimzi-kafka-operator/issues/12531#issuecomment-4077365869.