### PR TITLE
Add Strimzi Kafka CLI to Tools and Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Command-line tools, dashboards, configuration utilities:
 - *[Streamshub-console](https://github.com/streamshub/console)* - Web application designed to facilitate interactions with Apache Kafka leveraging Strimzi operator custom resources.
 - *[KubeStellar Console](https://github.com/kubestellar/console)* - Multi-cluster Kubernetes dashboard with a guided [Strimzi install mission](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-strimzi.json)
 - *[StreamsHub MCP](https://github.com/streamshub/streamshub-mcp)* - Model Context Protocol server that enables AI assistants to monitor, diagnose, and troubleshoot Strimzi-based Apache Kafka clusters on Kubernetes
+- *[Strimzi Kafka CLI](https://github.com/SystemCraftsman/strimzi-kafka-cli)* - Command line interface and MCP server for managing Strimzi-based Apache Kafka clusters on Kubernetes. 30+ tools for clusters, topics, users, connectors, MirrorMaker2, and node pools. ([website](https://strimzi-cli.dev))
 
 ### Integrations
 


### PR DESCRIPTION
Adds [Strimzi Kafka CLI](https://github.com/SystemCraftsman/strimzi-kafka-cli) to the Tools and Utilities section.

CLI and MCP server for managing Strimzi-based Apache Kafka clusters on Kubernetes. 30+ tools for clusters, topics, users, connectors, MirrorMaker2, and node pools.

- **PyPI:** [strimzi-kafka-cli](https://pypi.org/project/strimzi-kafka-cli/)
- **Website:** [strimzi-cli.dev](https://strimzi-cli.dev)